### PR TITLE
[Deprecate] point to praxis subtree

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Deprecated: Moved to Praxis
+
+The ethos-baseline history is now integrated into the Praxis monorepo under `shared/ethos-baseline/`.
+
+Active development continues at:
+
+https://github.com/itsmefelix-/praxis/tree/process/prd-task-scaffold/shared/ethos-baseline
+
+This repository remains for archival purposes only.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Deprecated: Moved to Praxis
 
-The ethos-baseline history is now integrated into the Praxis monorepo under `shared/ethos-baseline/`.
-
-Active development continues at:
-
-https://github.com/itsmefelix-/praxis/tree/process/prd-task-scaffold/shared/ethos-baseline
+The history now lives in the Praxis repo under `shared/ethos-baseline/`.
+See: https://github.com/itsmefelix-/praxis
 
 This repository remains for archival purposes only.


### PR DESCRIPTION
## Summary
- add README pointing to the new praxis subtree location for ethos-baseline history

## Testing
- n/a